### PR TITLE
Improved compatibility with Promise.all(), thanks to @gaogao-9's algorithm proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ ES6 promises don't provide any(). A small library to implement them.
 
 ```javascript
 var promiseAny = require('promise-any');
-var promises = [Promise.resolve('p1'), Promise.reject('p2')];
 
-promiseAny(promises).then(function(value) {
-    // value is p1 :)
+promiseAny([
+    Promise.reject('✗'),
+    Promise.resolve('✓'),
+]).then(function(value) {
+    // value is '✓' :)
+});
+
+promiseAny([
+    Promise.reject('✗'),
+    Promise.reject('✗'),
+]).catch(function(reasons) {
+    // reasons is ['✗', '✗'] :(
 });
 ```

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-module.exports = function(promises) {
-    return promises.reduce(function(anyPromise, promise) {
-        return anyPromise.catch(function(reason) {
-            return promise.then(function(result) {
-                return result;
-            });
-        });
-    }, Promise.reject("Promise array is empty"));
+'use strict';
+
+function reverse(promise) {
+    return new Promise((resolve, reject) => promise.then(reject, resolve));
+}
+
+module.exports = function promiseAny(iterable) {
+    return reverse(Promise.all([...iterable].map(reverse)));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-any",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "returns first successful promise. As in Promise.any() which is not part of the ES6 spec",
   "main": "index.js",
   "scripts": {

--- a/test/any.js
+++ b/test/any.js
@@ -1,41 +1,60 @@
 'use strict';
-var anyPromise = require('../index');
+var promiseAny = require('../index');
 var assert = require('assert');
 
-describe('Any test', function() {
-    it('should report failure for empty arrays', function(done) {
+describe('Any test', function () {
+    
+    it('should handle []', function (done) {
         let promises = [];
-        anyPromise(promises).then(function() {
-            done('Empty array should report failure');
-        }, function() {
+        promiseAny(promises).then(function (value) {
+            done(value);
+        }, function (reasons) {
+            assert.deepEqual([], reasons);
             done();
         });
     });
-    it('should handle success and then failure', function(done) {
+    
+    it('should handle [success, failure]', function (done) {
         let promises = [Promise.resolve('p1'), Promise.reject('p2')];
-        anyPromise(promises).then(function(value) {
+        promiseAny(promises).then(function(value) {
             assert.equal(value, 'p1');
             done();
-        }, function(error) {
-            done(error);
+        }, function (reasons) {
+            done(reasons);
         });
     });
-    it('should handle failure and then success', function(done) {
+    
+    it('should handle [failure, success]', function (done) {
         let promises = [Promise.reject('p1'), Promise.resolve('p2')];
-        anyPromise(promises).then(function(value) {
+        promiseAny(promises).then(function (value) {
             assert.equal(value, 'p2');
             done();
-        }, function(error) {
-            done(error);
+        }, function (reasons) {
+            done(reasons);
         });
     });
-    it('should handle failure', function(done) {
+    
+    it('should handle [failure, failure]', function (done) {
         let promises = [Promise.reject('p1'), Promise.reject('p2')];
-        anyPromise(promises).then(function(value) {
+        promiseAny(promises).then(function (value) {
             done('Got value ' + value);
-        }, function(error) {
-            assert.equal(error, 'p2');
+        }, function (reasons) {
+            assert.deepEqual(reasons, ['p1', 'p2']);
             done();
         });
     });
+    
+    it('should handle any iterables', function (done) {
+        let promises = (function *() {
+            yield Promise.reject('p1');
+            yield Promise.resolve('p2');
+        })();
+        promiseAny(promises).then(function(value) {
+            assert.equal(value, 'p2');
+            done();
+        }, function (reasons) {
+            done(reasons);
+        });
+    });
+    
 });


### PR DESCRIPTION
`Promies.all()`
- resolves with all values.
- rejects with the first reason.

So, `promsieAny()` should
- resolve with the first value.
- reject with all reasons.

Gist: https://gist.github.com/gaogao-9/bac4fbcb7f6b6a045a6f

I also bumped version from `0.0.1` to `0.1.0` :laughing: 
